### PR TITLE
Optimize opcode check

### DIFF
--- a/src/instruction.ts
+++ b/src/instruction.ts
@@ -40,10 +40,8 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= sum & 256 ? 1 : 0;
     sreg |= 1 & ((d & r) | (r & ~R) | (~R & d)) ? 0x20 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* ADD, 0000 11rd dddd rrrr */
-  if ((opcode & 0xfc00) === 0xc00) {
+  } else if ((opcode & 0xfc00) === 0xc00) {
+    /* ADD, 0000 11rd dddd rrrr */
     const d = cpu.data[(opcode & 0x1f0) >> 4];
     const r = cpu.data[(opcode & 0xf) | ((opcode & 0x200) >> 5)];
     const R = (d + r) & 255;
@@ -56,10 +54,8 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= (d + r) & 256 ? 1 : 0;
     sreg |= 1 & ((d & r) | (r & ~R) | (~R & d)) ? 0x20 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* ADIW, 1001 0110 KKdd KKKK */
-  if ((opcode & 0xff00) === 0x9600) {
+  } else if ((opcode & 0xff00) === 0x9600) {
+    /* ADIW, 1001 0110 KKdd KKKK */
     const addr = 2 * ((opcode & 0x30) >> 4) + 24;
     const value = cpu.dataView.getUint16(addr, true);
     const R = (value + ((opcode & 0xf) | ((opcode & 0xc0) >> 2))) & 0xffff;
@@ -72,10 +68,8 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= ~R & value & 0x8000 ? 1 : 0;
     cpu.data[95] = sreg;
     cpu.cycles++;
-  }
-
-  /* AND, 0010 00rd dddd rrrr */
-  if ((opcode & 0xfc00) === 0x2000) {
+  } else if ((opcode & 0xfc00) === 0x2000) {
+    /* AND, 0010 00rd dddd rrrr */
     const R = cpu.data[(opcode & 0x1f0) >> 4] & cpu.data[(opcode & 0xf) | ((opcode & 0x200) >> 5)];
     cpu.data[(opcode & 0x1f0) >> 4] = R;
     let sreg = cpu.data[95] & 0xe1;
@@ -83,10 +77,8 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= 128 & R ? 4 : 0;
     sreg |= ((sreg >> 2) & 1) ^ ((sreg >> 3) & 1) ? 0x10 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* ANDI, 0111 KKKK dddd KKKK */
-  if ((opcode & 0xf000) === 0x7000) {
+  } else if ((opcode & 0xf000) === 0x7000) {
+    /* ANDI, 0111 KKKK dddd KKKK */
     const R = cpu.data[((opcode & 0xf0) >> 4) + 16] & ((opcode & 0xf) | ((opcode & 0xf00) >> 4));
     cpu.data[((opcode & 0xf0) >> 4) + 16] = R;
     let sreg = cpu.data[95] & 0xe1;
@@ -94,10 +86,8 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= 128 & R ? 4 : 0;
     sreg |= ((sreg >> 2) & 1) ^ ((sreg >> 3) & 1) ? 0x10 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* ASR, 1001 010d dddd 0101 */
-  if ((opcode & 0xfe0f) === 0x9405) {
+  } else if ((opcode & 0xfe0f) === 0x9405) {
+    /* ASR, 1001 010d dddd 0101 */
     const value = cpu.data[(opcode & 0x1f0) >> 4];
     const R = (value >>> 1) | (128 & value);
     cpu.data[(opcode & 0x1f0) >> 4] = R;
@@ -108,50 +98,36 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= ((sreg >> 2) & 1) ^ (sreg & 1) ? 8 : 0;
     sreg |= ((sreg >> 2) & 1) ^ ((sreg >> 3) & 1) ? 0x10 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* BCLR, 1001 0100 1sss 1000 */
-  if ((opcode & 0xff8f) === 0x9488) {
+  } else if ((opcode & 0xff8f) === 0x9488) {
+    /* BCLR, 1001 0100 1sss 1000 */
     cpu.data[95] &= ~(1 << ((opcode & 0x70) >> 4));
-  }
-
-  /* BLD, 1111 100d dddd 0bbb */
-  if ((opcode & 0xfe08) === 0xf800) {
+  } else if ((opcode & 0xfe08) === 0xf800) {
+    /* BLD, 1111 100d dddd 0bbb */
     const b = opcode & 7;
     const d = (opcode & 0x1f0) >> 4;
     cpu.data[d] = (~(1 << b) & cpu.data[d]) | (((cpu.data[95] >> 6) & 1) << b);
-  }
-
-  /* BRBC, 1111 01kk kkkk ksss */
-  if ((opcode & 0xfc00) === 0xf400) {
+  } else if ((opcode & 0xfc00) === 0xf400) {
+    /* BRBC, 1111 01kk kkkk ksss */
     if (!(cpu.data[95] & (1 << (opcode & 7)))) {
       cpu.pc = cpu.pc + (((opcode & 0x1f8) >> 3) - (opcode & 0x200 ? 0x40 : 0));
       cpu.cycles++;
     }
-  }
-
-  /* BRBS, 1111 00kk kkkk ksss */
-  if ((opcode & 0xfc00) === 0xf000) {
+  } else if ((opcode & 0xfc00) === 0xf000) {
+    /* BRBS, 1111 00kk kkkk ksss */
     if (cpu.data[95] & (1 << (opcode & 7))) {
       cpu.pc = cpu.pc + (((opcode & 0x1f8) >> 3) - (opcode & 0x200 ? 0x40 : 0));
       cpu.cycles++;
     }
-  }
-
-  /* BSET, 1001 0100 0sss 1000 */
-  if ((opcode & 0xff8f) === 0x9408) {
+  } else if ((opcode & 0xff8f) === 0x9408) {
+    /* BSET, 1001 0100 0sss 1000 */
     cpu.data[95] |= 1 << ((opcode & 0x70) >> 4);
-  }
-
-  /* BST, 1111 101d dddd 0bbb */
-  if ((opcode & 0xfe08) === 0xfa00) {
+  } else if ((opcode & 0xfe08) === 0xfa00) {
+    /* BST, 1111 101d dddd 0bbb */
     const d = cpu.data[(opcode & 0x1f0) >> 4];
     const b = opcode & 7;
     cpu.data[95] = (cpu.data[95] & 0xbf) | ((d >> b) & 1 ? 0x40 : 0);
-  }
-
-  /* CALL, 1001 010k kkkk 111k kkkk kkkk kkkk kkkk */
-  if ((opcode & 0xfe0e) === 0x940e) {
+  } else if ((opcode & 0xfe0e) === 0x940e) {
+    /* CALL, 1001 010k kkkk 111k kkkk kkkk kkkk kkkk */
     const k = cpu.progMem[cpu.pc + 1] | ((opcode & 1) << 16) | ((opcode & 0x1f0) << 13);
     const ret = cpu.pc + 2;
     const sp = cpu.dataView.getUint16(93, true);
@@ -160,18 +136,14 @@ export function avrInstruction(cpu: ICPU) {
     cpu.dataView.setUint16(93, sp - 2, true);
     cpu.pc = k - 1;
     cpu.cycles += 4;
-  }
-
-  /* CBI, 1001 1000 AAAA Abbb */
-  if ((opcode & 0xff00) === 0x9800) {
+  } else if ((opcode & 0xff00) === 0x9800) {
+    /* CBI, 1001 1000 AAAA Abbb */
     const A = opcode & 0xf8;
     const b = opcode & 7;
     const R = cpu.readData((A >> 3) + 32);
     cpu.writeData((A >> 3) + 32, R & ~(1 << b));
-  }
-
-  /* COM, 1001 010d dddd 0000 */
-  if ((opcode & 0xfe0f) === 0x9400) {
+  } else if ((opcode & 0xfe0f) === 0x9400) {
+    /* COM, 1001 010d dddd 0000 */
     const d = (opcode & 0x1f0) >> 4;
     const R = 255 - cpu.data[d];
     cpu.data[d] = R;
@@ -180,10 +152,8 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= 128 & R ? 4 : 0;
     sreg |= ((sreg >> 2) & 1) ^ ((sreg >> 3) & 1) ? 0x10 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* CP, 0001 01rd dddd rrrr */
-  if ((opcode & 0xfc00) === 0x1400) {
+  } else if ((opcode & 0xfc00) === 0x1400) {
+    /* CP, 0001 01rd dddd rrrr */
     const val1 = cpu.data[(opcode & 0x1f0) >> 4];
     const val2 = cpu.data[(opcode & 0xf) | ((opcode & 0x200) >> 5)];
     const R = val1 - val2;
@@ -195,10 +165,8 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= val2 > val1 ? 1 : 0;
     sreg |= 1 & ((~val1 & val2) | (val2 & R) | (R & ~val1)) ? 0x20 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* CPC, 0000 01rd dddd rrrr */
-  if ((opcode & 0xfc00) === 0x400) {
+  } else if ((opcode & 0xfc00) === 0x400) {
+    /* CPC, 0000 01rd dddd rrrr */
     const arg1 = cpu.data[(opcode & 0x1f0) >> 4];
     const arg2 = cpu.data[(opcode & 0xf) | ((opcode & 0x200) >> 5)];
     let sreg = cpu.data[95];
@@ -209,10 +177,8 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= ((sreg >> 2) & 1) ^ ((sreg >> 3) & 1) ? 0x10 : 0;
     sreg |= 1 & ((~arg1 & arg2) | (arg2 & r) | (r & ~arg1)) ? 0x20 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* CPI, 0011 KKKK dddd KKKK */
-  if ((opcode & 0xf000) === 0x3000) {
+  } else if ((opcode & 0xf000) === 0x3000) {
+    /* CPI, 0011 KKKK dddd KKKK */
     const arg1 = cpu.data[((opcode & 0xf0) >> 4) + 16];
     const arg2 = (opcode & 0xf) | ((opcode & 0xf00) >> 4);
     const r = arg1 - arg2;
@@ -224,20 +190,16 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= arg2 > arg1 ? 1 : 0;
     sreg |= 1 & ((~arg1 & arg2) | (arg2 & r) | (r & ~arg1)) ? 0x20 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* CPSE, 0001 00rd dddd rrrr */
-  if ((opcode & 0xfc00) === 0x1000) {
+  } else if ((opcode & 0xfc00) === 0x1000) {
+    /* CPSE, 0001 00rd dddd rrrr */
     if (cpu.data[(opcode & 0x1f0) >> 4] === cpu.data[(opcode & 0xf) | ((opcode & 0x200) >> 5)]) {
       const nextOpcode = cpu.progMem[cpu.pc + 1];
       const skipSize = isTwoWordInstruction(nextOpcode) ? 2 : 1;
       cpu.pc += skipSize;
       cpu.cycles += skipSize;
     }
-  }
-
-  /* DEC, 1001 010d dddd 1010 */
-  if ((opcode & 0xfe0f) === 0x940a) {
+  } else if ((opcode & 0xfe0f) === 0x940a) {
+    /* DEC, 1001 010d dddd 1010 */
     const value = cpu.data[(opcode & 0x1f0) >> 4];
     const R = value - 1;
     cpu.data[(opcode & 0x1f0) >> 4] = R;
@@ -247,10 +209,8 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= 128 === value ? 8 : 0;
     sreg |= ((sreg >> 2) & 1) ^ ((sreg >> 3) & 1) ? 0x10 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* EOR, 0010 01rd dddd rrrr */
-  if ((opcode & 0xfc00) === 0x2400) {
+  } else if ((opcode & 0xfc00) === 0x2400) {
+    /* EOR, 0010 01rd dddd rrrr */
     const R = cpu.data[(opcode & 0x1f0) >> 4] ^ cpu.data[(opcode & 0xf) | ((opcode & 0x200) >> 5)];
     cpu.data[(opcode & 0x1f0) >> 4] = R;
     let sreg = cpu.data[95] & 0xe1;
@@ -258,40 +218,32 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= 128 & R ? 4 : 0;
     sreg |= ((sreg >> 2) & 1) ^ ((sreg >> 3) & 1) ? 0x10 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* FMUL, 0000 0011 0ddd 1rrr */
-  if ((opcode & 0xff88) === 0x308) {
+  } else if ((opcode & 0xff88) === 0x308) {
+    /* FMUL, 0000 0011 0ddd 1rrr */
     const v1 = cpu.data[((opcode & 0x70) >> 4) + 16];
     const v2 = cpu.data[(opcode & 7) + 16];
     const R = (v1 * v2) << 1;
     cpu.dataView.setUint16(0, R, true);
     cpu.data[95] = (cpu.data[95] & 0xfc) | (0xffff & R ? 0 : 2) | ((v1 * v2) & 0x8000 ? 1 : 0);
     cpu.cycles++;
-  }
-
-  /* FMULS, 0000 0011 1ddd 0rrr */
-  if ((opcode & 0xff88) === 0x380) {
+  } else if ((opcode & 0xff88) === 0x380) {
+    /* FMULS, 0000 0011 1ddd 0rrr */
     const v1 = cpu.dataView.getInt8(((opcode & 0x70) >> 4) + 16);
     const v2 = cpu.dataView.getInt8((opcode & 7) + 16);
     const R = (v1 * v2) << 1;
     cpu.dataView.setInt16(0, R, true);
     cpu.data[95] = (cpu.data[95] & 0xfc) | (0xffff & R ? 0 : 2) | ((v1 * v2) & 0x8000 ? 1 : 0);
     cpu.cycles++;
-  }
-
-  /* FMULSU, 0000 0011 1ddd 1rrr */
-  if ((opcode & 0xff88) === 0x388) {
+  } else if ((opcode & 0xff88) === 0x388) {
+    /* FMULSU, 0000 0011 1ddd 1rrr */
     const v1 = cpu.dataView.getInt8(((opcode & 0x70) >> 4) + 16);
     const v2 = cpu.data[(opcode & 7) + 16];
     const R = (v1 * v2) << 1;
     cpu.dataView.setInt16(0, R, true);
     cpu.data[95] = (cpu.data[95] & 0xfc) | (0xffff & R ? 2 : 0) | ((v1 * v2) & 0x8000 ? 1 : 0);
     cpu.cycles++;
-  }
-
-  /* ICALL, 1001 0101 0000 1001 */
-  if (opcode === 0x9509) {
+  } else if (opcode === 0x9509) {
+    /* ICALL, 1001 0101 0000 1001 */
     const retAddr = cpu.pc + 1;
     const sp = cpu.dataView.getUint16(93, true);
     cpu.data[sp] = retAddr & 255;
@@ -299,22 +251,16 @@ export function avrInstruction(cpu: ICPU) {
     cpu.dataView.setUint16(93, sp - 2, true);
     cpu.pc = cpu.dataView.getUint16(30, true) - 1;
     cpu.cycles += 2;
-  }
-
-  /* IJMP, 1001 0100 0000 1001 */
-  if (opcode === 0x9409) {
+  } else if (opcode === 0x9409) {
+    /* IJMP, 1001 0100 0000 1001 */
     cpu.pc = cpu.dataView.getUint16(30, true) - 1;
     cpu.cycles++;
-  }
-
-  /* IN, 1011 0AAd dddd AAAA */
-  if ((opcode & 0xf800) === 0xb000) {
+  } else if ((opcode & 0xf800) === 0xb000) {
+    /* IN, 1011 0AAd dddd AAAA */
     const i = cpu.readData(((opcode & 0xf) | ((opcode & 0x600) >> 5)) + 32);
     cpu.data[(opcode & 0x1f0) >> 4] = i;
-  }
-
-  /* INC, 1001 010d dddd 0011 */
-  if ((opcode & 0xfe0f) === 0x9403) {
+  } else if ((opcode & 0xfe0f) === 0x9403) {
+    /* INC, 1001 010d dddd 0011 */
     const d = cpu.data[(opcode & 0x1f0) >> 4];
     const r = (d + 1) & 255;
     cpu.data[(opcode & 0x1f0) >> 4] = r;
@@ -324,97 +270,71 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= 127 === d ? 8 : 0;
     sreg |= ((sreg >> 2) & 1) ^ ((sreg >> 3) & 1) ? 0x10 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* JMP, 1001 010k kkkk 110k kkkk kkkk kkkk kkkk */
-  if ((opcode & 0xfe0e) === 0x940c) {
+  } else if ((opcode & 0xfe0e) === 0x940c) {
+    /* JMP, 1001 010k kkkk 110k kkkk kkkk kkkk kkkk */
     cpu.pc = (cpu.progMem[cpu.pc + 1] | ((opcode & 1) << 16) | ((opcode & 0x1f0) << 13)) - 1;
     cpu.cycles += 2;
-  }
-
-  /* LAC, 1001 001r rrrr 0110 */
-  if ((opcode & 0xfe0f) === 0x9206) {
+  } else if ((opcode & 0xfe0f) === 0x9206) {
+    /* LAC, 1001 001r rrrr 0110 */
     const r = (opcode & 0x1f0) >> 4;
     const clear = cpu.data[r];
     const value = cpu.readData(cpu.dataView.getUint16(30, true));
     cpu.writeData(cpu.dataView.getUint16(30, true), value & (255 - clear));
     cpu.data[r] = value;
-  }
-
-  /* LAS, 1001 001r rrrr 0101 */
-  if ((opcode & 0xfe0f) === 0x9205) {
+  } else if ((opcode & 0xfe0f) === 0x9205) {
+    /* LAS, 1001 001r rrrr 0101 */
     const r = (opcode & 0x1f0) >> 4;
     const set = cpu.data[r];
     const value = cpu.readData(cpu.dataView.getUint16(30, true));
     cpu.writeData(cpu.dataView.getUint16(30, true), value | set);
     cpu.data[r] = value;
-  }
-
-  /* LAT, 1001 001r rrrr 0111 */
-  if ((opcode & 0xfe0f) === 0x9207) {
+  } else if ((opcode & 0xfe0f) === 0x9207) {
+    /* LAT, 1001 001r rrrr 0111 */
     const r = cpu.data[(opcode & 0x1f0) >> 4];
     const R = cpu.readData(cpu.dataView.getUint16(30, true));
     cpu.writeData(cpu.dataView.getUint16(30, true), r ^ R);
     cpu.data[(opcode & 0x1f0) >> 4] = R;
-  }
-
-  /* LDI, 1110 KKKK dddd KKKK */
-  if ((opcode & 0xf000) === 0xe000) {
+  } else if ((opcode & 0xf000) === 0xe000) {
+    /* LDI, 1110 KKKK dddd KKKK */
     cpu.data[((opcode & 0xf0) >> 4) + 16] = (opcode & 0xf) | ((opcode & 0xf00) >> 4);
-  }
-
-  /* LDS, 1001 000d dddd 0000 kkkk kkkk kkkk kkkk */
-  if ((opcode & 0xfe0f) === 0x9000) {
+  } else if ((opcode & 0xfe0f) === 0x9000) {
+    /* LDS, 1001 000d dddd 0000 kkkk kkkk kkkk kkkk */
     const value = cpu.readData(cpu.progMem[cpu.pc + 1]);
     cpu.data[(opcode & 0x1f0) >> 4] = value;
     cpu.pc++;
     cpu.cycles++;
-  }
-
-  /* LDX, 1001 000d dddd 1100 */
-  if ((opcode & 0xfe0f) === 0x900c) {
+  } else if ((opcode & 0xfe0f) === 0x900c) {
+    /* LDX, 1001 000d dddd 1100 */
     cpu.data[(opcode & 0x1f0) >> 4] = cpu.readData(cpu.dataView.getUint16(26, true));
-  }
-
-  /* LDX(INC), 1001 000d dddd 1101 */
-  if ((opcode & 0xfe0f) === 0x900d) {
+  } else if ((opcode & 0xfe0f) === 0x900d) {
+    /* LDX(INC), 1001 000d dddd 1101 */
     const x = cpu.dataView.getUint16(26, true);
     cpu.data[(opcode & 0x1f0) >> 4] = cpu.readData(x);
     cpu.dataView.setUint16(26, x + 1, true);
     cpu.cycles++;
-  }
-
-  /* LDX(DEC), 1001 000d dddd 1110 */
-  if ((opcode & 0xfe0f) === 0x900e) {
+  } else if ((opcode & 0xfe0f) === 0x900e) {
+    /* LDX(DEC), 1001 000d dddd 1110 */
     const x = cpu.dataView.getUint16(26, true) - 1;
     cpu.dataView.setUint16(26, x, true);
     cpu.data[(opcode & 0x1f0) >> 4] = cpu.readData(x);
     cpu.cycles += 2;
-  }
-
-  /* LDY, 1000 000d dddd 1000 */
-  if ((opcode & 0xfe0f) === 0x8008) {
+  } else if ((opcode & 0xfe0f) === 0x8008) {
+    /* LDY, 1000 000d dddd 1000 */
     cpu.data[(opcode & 0x1f0) >> 4] = cpu.readData(cpu.dataView.getUint16(28, true));
-  }
-
-  /* LDY(INC), 1001 000d dddd 1001 */
-  if ((opcode & 0xfe0f) === 0x9009) {
+  } else if ((opcode & 0xfe0f) === 0x9009) {
+    /* LDY(INC), 1001 000d dddd 1001 */
     const y = cpu.dataView.getUint16(28, true);
     cpu.data[(opcode & 0x1f0) >> 4] = cpu.readData(y);
     cpu.dataView.setUint16(28, y + 1, true);
     cpu.cycles++;
-  }
-
-  /* LDY(DEC), 1001 000d dddd 1010 */
-  if ((opcode & 0xfe0f) === 0x900a) {
+  } else if ((opcode & 0xfe0f) === 0x900a) {
+    /* LDY(DEC), 1001 000d dddd 1010 */
     const y = cpu.dataView.getUint16(28, true) - 1;
     cpu.dataView.setUint16(28, y, true);
     cpu.data[(opcode & 0x1f0) >> 4] = cpu.readData(y);
     cpu.cycles += 2;
-  }
-
-  /* LDDY, 10q0 qq0d dddd 1qqq */
-  if (
+  } else if (
+    /* LDDY, 10q0 qq0d dddd 1qqq */
     (opcode & 0xd208) === 0x8008 &&
     (opcode & 7) | ((opcode & 0xc00) >> 7) | ((opcode & 0x2000) >> 8)
   ) {
@@ -423,31 +343,23 @@ export function avrInstruction(cpu: ICPU) {
         ((opcode & 7) | ((opcode & 0xc00) >> 7) | ((opcode & 0x2000) >> 8))
     );
     cpu.cycles += 2;
-  }
-
-  /* LDZ, 1000 000d dddd 0000 */
-  if ((opcode & 0xfe0f) === 0x8000) {
+  } else if ((opcode & 0xfe0f) === 0x8000) {
+    /* LDZ, 1000 000d dddd 0000 */
     cpu.data[(opcode & 0x1f0) >> 4] = cpu.readData(cpu.dataView.getUint16(30, true));
-  }
-
-  /* LDZ(INC), 1001 000d dddd 0001 */
-  if ((opcode & 0xfe0f) === 0x9001) {
+  } else if ((opcode & 0xfe0f) === 0x9001) {
+    /* LDZ(INC), 1001 000d dddd 0001 */
     const z = cpu.dataView.getUint16(30, true);
     cpu.data[(opcode & 0x1f0) >> 4] = cpu.readData(z);
     cpu.dataView.setUint16(30, z + 1, true);
     cpu.cycles++;
-  }
-
-  /* LDZ(DEC), 1001 000d dddd 0010 */
-  if ((opcode & 0xfe0f) === 0x9002) {
+  } else if ((opcode & 0xfe0f) === 0x9002) {
+    /* LDZ(DEC), 1001 000d dddd 0010 */
     const z = cpu.dataView.getUint16(30, true) - 1;
     cpu.dataView.setUint16(30, z, true);
     cpu.data[(opcode & 0x1f0) >> 4] = cpu.readData(z);
     cpu.cycles += 2;
-  }
-
-  /* LDDZ, 10q0 qq0d dddd 0qqq */
-  if (
+  } else if (
+    /* LDDZ, 10q0 qq0d dddd 0qqq */
     (opcode & 0xd208) === 0x8000 &&
     (opcode & 7) | ((opcode & 0xc00) >> 7) | ((opcode & 0x2000) >> 8)
   ) {
@@ -456,30 +368,22 @@ export function avrInstruction(cpu: ICPU) {
         ((opcode & 7) | ((opcode & 0xc00) >> 7) | ((opcode & 0x2000) >> 8))
     );
     cpu.cycles += 2;
-  }
-
-  /* LPM, 1001 0101 1100 1000 */
-  if (opcode === 0x95c8) {
+  } else if (opcode === 0x95c8) {
+    /* LPM, 1001 0101 1100 1000 */
     cpu.data[0] = cpu.progBytes[cpu.dataView.getUint16(30, true)];
     cpu.cycles += 2;
-  }
-
-  /* LPM(REG), 1001 000d dddd 0100 */
-  if ((opcode & 0xfe0f) === 0x9004) {
+  } else if ((opcode & 0xfe0f) === 0x9004) {
+    /* LPM(REG), 1001 000d dddd 0100 */
     cpu.data[(opcode & 0x1f0) >> 4] = cpu.progBytes[cpu.dataView.getUint16(30, true)];
     cpu.cycles += 2;
-  }
-
-  /* LPM(INC), 1001 000d dddd 0101 */
-  if ((opcode & 0xfe0f) === 0x9005) {
+  } else if ((opcode & 0xfe0f) === 0x9005) {
+    /* LPM(INC), 1001 000d dddd 0101 */
     const i = cpu.dataView.getUint16(30, true);
     cpu.data[(opcode & 0x1f0) >> 4] = cpu.progBytes[i];
     cpu.dataView.setUint16(30, i + 1, true);
     cpu.cycles += 2;
-  }
-
-  /* LSR, 1001 010d dddd 0110 */
-  if ((opcode & 0xfe0f) === 0x9406) {
+  } else if ((opcode & 0xfe0f) === 0x9406) {
+    /* LSR, 1001 010d dddd 0110 */
     const value = cpu.data[(opcode & 0x1f0) >> 4];
     const R = value >>> 1;
     cpu.data[(opcode & 0x1f0) >> 4] = R;
@@ -489,48 +393,36 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= ((sreg >> 2) & 1) ^ (sreg & 1) ? 8 : 0;
     sreg |= ((sreg >> 2) & 1) ^ ((sreg >> 3) & 1) ? 0x10 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* MOV, 0010 11rd dddd rrrr */
-  if ((opcode & 0xfc00) === 0x2c00) {
+  } else if ((opcode & 0xfc00) === 0x2c00) {
+    /* MOV, 0010 11rd dddd rrrr */
     cpu.data[(opcode & 0x1f0) >> 4] = cpu.data[(opcode & 0xf) | ((opcode & 0x200) >> 5)];
-  }
-
-  /* MOVW, 0000 0001 dddd rrrr */
-  if ((opcode & 0xff00) === 0x100) {
+  } else if ((opcode & 0xff00) === 0x100) {
+    /* MOVW, 0000 0001 dddd rrrr */
     const r2 = 2 * (opcode & 0xf);
     const d2 = 2 * ((opcode & 0xf0) >> 4);
     cpu.data[d2] = cpu.data[r2];
     cpu.data[d2 + 1] = cpu.data[r2 + 1];
-  }
-
-  /* MUL, 1001 11rd dddd rrrr */
-  if ((opcode & 0xfc00) === 0x9c00) {
+  } else if ((opcode & 0xfc00) === 0x9c00) {
+    /* MUL, 1001 11rd dddd rrrr */
     const R = cpu.data[(opcode & 0x1f0) >> 4] * cpu.data[(opcode & 0xf) | ((opcode & 0x200) >> 5)];
     cpu.dataView.setUint16(0, R, true);
     cpu.data[95] = (cpu.data[95] & 0xfc) | (0xffff & R ? 0 : 2) | (0x8000 & R ? 1 : 0);
     cpu.cycles++;
-  }
-
-  /* MULS, 0000 0010 dddd rrrr */
-  if ((opcode & 0xff00) === 0x200) {
+  } else if ((opcode & 0xff00) === 0x200) {
+    /* MULS, 0000 0010 dddd rrrr */
     const R =
       cpu.dataView.getInt8(((opcode & 0xf0) >> 4) + 16) * cpu.dataView.getInt8((opcode & 0xf) + 16);
     cpu.dataView.setInt16(0, R, true);
     cpu.data[95] = (cpu.data[95] & 0xfc) | (0xffff & R ? 0 : 2) | (0x8000 & R ? 1 : 0);
     cpu.cycles++;
-  }
-
-  /* MULSU, 0000 0011 0ddd 0rrr */
-  if ((opcode & 0xff88) === 0x300) {
+  } else if ((opcode & 0xff88) === 0x300) {
+    /* MULSU, 0000 0011 0ddd 0rrr */
     const R = cpu.dataView.getInt8(((opcode & 0x70) >> 4) + 16) * cpu.data[(opcode & 7) + 16];
     cpu.dataView.setInt16(0, R, true);
     cpu.data[95] = (cpu.data[95] & 0xfc) | (0xffff & R ? 0 : 2) | (0x8000 & R ? 1 : 0);
     cpu.cycles++;
-  }
-
-  /* NEG, 1001 010d dddd 0001 */
-  if ((opcode & 0xfe0f) === 0x9401) {
+  } else if ((opcode & 0xfe0f) === 0x9401) {
+    /* NEG, 1001 010d dddd 0001 */
     const d = (opcode & 0x1f0) >> 4;
     const value = cpu.data[d];
     const R = 0 - value;
@@ -543,15 +435,11 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= R ? 1 : 0;
     sreg |= 1 & (R | value) ? 0x20 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* NOP, 0000 0000 0000 0000 */
-  if (opcode === 0) {
+  } else if (opcode === 0) {
+    /* NOP, 0000 0000 0000 0000 */
     /* NOP */
-  }
-
-  /* OR, 0010 10rd dddd rrrr */
-  if ((opcode & 0xfc00) === 0x2800) {
+  } else if ((opcode & 0xfc00) === 0x2800) {
+    /* OR, 0010 10rd dddd rrrr */
     const R = cpu.data[(opcode & 0x1f0) >> 4] | cpu.data[(opcode & 0xf) | ((opcode & 0x200) >> 5)];
     cpu.data[(opcode & 0x1f0) >> 4] = R;
     let sreg = cpu.data[95] & 0xe1;
@@ -559,10 +447,8 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= 128 & R ? 4 : 0;
     sreg |= ((sreg >> 2) & 1) ^ ((sreg >> 3) & 1) ? 0x10 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* SBR, 0110 KKKK dddd KKKK */
-  if ((opcode & 0xf000) === 0x6000) {
+  } else if ((opcode & 0xf000) === 0x6000) {
+    /* SBR, 0110 KKKK dddd KKKK */
     const R = cpu.data[((opcode & 0xf0) >> 4) + 16] | ((opcode & 0xf) | ((opcode & 0xf00) >> 4));
     cpu.data[((opcode & 0xf0) >> 4) + 16] = R;
     let sreg = cpu.data[95] & 0xe1;
@@ -570,31 +456,23 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= 128 & R ? 4 : 0;
     sreg |= ((sreg >> 2) & 1) ^ ((sreg >> 3) & 1) ? 0x10 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* OUT, 1011 1AAr rrrr AAAA */
-  if ((opcode & 0xf800) === 0xb800) {
+  } else if ((opcode & 0xf800) === 0xb800) {
+    /* OUT, 1011 1AAr rrrr AAAA */
     cpu.writeData(((opcode & 0xf) | ((opcode & 0x600) >> 5)) + 32, cpu.data[(opcode & 0x1f0) >> 4]);
-  }
-
-  /* POP, 1001 000d dddd 1111 */
-  if ((opcode & 0xfe0f) === 0x900f) {
+  } else if ((opcode & 0xfe0f) === 0x900f) {
+    /* POP, 1001 000d dddd 1111 */
     const value = cpu.dataView.getUint16(93, true) + 1;
     cpu.dataView.setUint16(93, value, true);
     cpu.data[(opcode & 0x1f0) >> 4] = cpu.data[value];
     cpu.cycles++;
-  }
-
-  /* PUSH, 1001 001d dddd 1111 */
-  if ((opcode & 0xfe0f) === 0x920f) {
+  } else if ((opcode & 0xfe0f) === 0x920f) {
+    /* PUSH, 1001 001d dddd 1111 */
     const value = cpu.dataView.getUint16(93, true);
     cpu.data[value] = cpu.data[(opcode & 0x1f0) >> 4];
     cpu.dataView.setUint16(93, value - 1, true);
     cpu.cycles++;
-  }
-
-  /* RCALL, 1101 kkkk kkkk kkkk */
-  if ((opcode & 0xf000) === 0xd000) {
+  } else if ((opcode & 0xf000) === 0xd000) {
+    /* RCALL, 1101 kkkk kkkk kkkk */
     const k = (opcode & 0x7ff) - (opcode & 0x800 ? 0x800 : 0);
     const retAddr = cpu.pc + 1;
     const sp = cpu.dataView.getUint16(93, true);
@@ -603,33 +481,25 @@ export function avrInstruction(cpu: ICPU) {
     cpu.dataView.setUint16(93, sp - 2, true);
     cpu.pc += k;
     cpu.cycles += 3;
-  }
-
-  /* RET, 1001 0101 0000 1000 */
-  if (opcode === 0x9508) {
+  } else if (opcode === 0x9508) {
+    /* RET, 1001 0101 0000 1000 */
     const i = cpu.dataView.getUint16(93, true) + 2;
     cpu.dataView.setUint16(93, i, true);
     cpu.pc = (cpu.data[i - 1] << 8) + cpu.data[i] - 1;
     cpu.cycles += 4;
-  }
-
-  /* RETI, 1001 0101 0001 1000 */
-  if (opcode === 0x9518) {
+  } else if (opcode === 0x9518) {
+    /* RETI, 1001 0101 0001 1000 */
     const i = cpu.dataView.getUint16(93, true) + 2;
     cpu.dataView.setUint16(93, i, true);
     cpu.pc = (cpu.data[i - 1] << 8) + cpu.data[i] - 1;
     cpu.cycles += 4;
     cpu.data[95] |= 0x80; // Enable interrupts
-  }
-
-  /* RJMP, 1100 kkkk kkkk kkkk */
-  if ((opcode & 0xf000) === 0xc000) {
+  } else if ((opcode & 0xf000) === 0xc000) {
+    /* RJMP, 1100 kkkk kkkk kkkk */
     cpu.pc = cpu.pc + ((opcode & 0x7ff) - (opcode & 0x800 ? 0x800 : 0));
     cpu.cycles++;
-  }
-
-  /* ROR, 1001 010d dddd 0111 */
-  if ((opcode & 0xfe0f) === 0x9407) {
+  } else if ((opcode & 0xfe0f) === 0x9407) {
+    /* ROR, 1001 010d dddd 0111 */
     const d = cpu.data[(opcode & 0x1f0) >> 4];
     const r = (d >>> 1) | ((cpu.data[95] & 1) << 7);
     cpu.data[(opcode & 0x1f0) >> 4] = r;
@@ -640,10 +510,8 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= ((sreg >> 2) & 1) ^ (sreg & 1) ? 8 : 0;
     sreg |= ((sreg >> 2) & 1) ^ ((sreg >> 3) & 1) ? 0x10 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* SBC, 0000 10rd dddd rrrr */
-  if ((opcode & 0xfc00) === 0x800) {
+  } else if ((opcode & 0xfc00) === 0x800) {
+    /* SBC, 0000 10rd dddd rrrr */
     const val1 = cpu.data[(opcode & 0x1f0) >> 4];
     const val2 = cpu.data[(opcode & 0xf) | ((opcode & 0x200) >> 5)];
     let sreg = cpu.data[95];
@@ -655,10 +523,8 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= ((sreg >> 2) & 1) ^ ((sreg >> 3) & 1) ? 0x10 : 0;
     sreg |= 1 & ((~val1 & val2) | (val2 & R) | (R & ~val1)) ? 0x20 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* SBCI, 0100 KKKK dddd KKKK */
-  if ((opcode & 0xf000) === 0x4000) {
+  } else if ((opcode & 0xf000) === 0x4000) {
+    /* SBCI, 0100 KKKK dddd KKKK */
     const val1 = cpu.data[((opcode & 0xf0) >> 4) + 16];
     const val2 = (opcode & 0xf) | ((opcode & 0xf00) >> 4);
     let sreg = cpu.data[95];
@@ -670,17 +536,13 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= ((sreg >> 2) & 1) ^ ((sreg >> 3) & 1) ? 0x10 : 0;
     sreg |= 1 & ((~val1 & val2) | (val2 & R) | (R & ~val1)) ? 0x20 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* SBI, 1001 1010 AAAA Abbb */
-  if ((opcode & 0xff00) === 0x9a00) {
+  } else if ((opcode & 0xff00) === 0x9a00) {
+    /* SBI, 1001 1010 AAAA Abbb */
     const target = ((opcode & 0xf8) >> 3) + 32;
     cpu.writeData(target, cpu.readData(target) | (1 << (opcode & 7)));
     cpu.cycles++;
-  }
-
-  /* SBIC, 1001 1001 AAAA Abbb */
-  if ((opcode & 0xff00) === 0x9900) {
+  } else if ((opcode & 0xff00) === 0x9900) {
+    /* SBIC, 1001 1001 AAAA Abbb */
     const value = cpu.readData(((opcode & 0xf8) >> 3) + 32);
     if (!(value & (1 << (opcode & 7)))) {
       const nextOpcode = cpu.progMem[cpu.pc + 1];
@@ -688,10 +550,8 @@ export function avrInstruction(cpu: ICPU) {
       cpu.cycles += skipSize;
       cpu.pc += skipSize;
     }
-  }
-
-  /* SBIS, 1001 1011 AAAA Abbb */
-  if ((opcode & 0xff00) === 0x9b00) {
+  } else if ((opcode & 0xff00) === 0x9b00) {
+    /* SBIS, 1001 1011 AAAA Abbb */
     const value = cpu.readData(((opcode & 0xf8) >> 3) + 32);
     if (value & (1 << (opcode & 7))) {
       const nextOpcode = cpu.progMem[cpu.pc + 1];
@@ -699,10 +559,8 @@ export function avrInstruction(cpu: ICPU) {
       cpu.cycles += skipSize;
       cpu.pc += skipSize;
     }
-  }
-
-  /* SBIW, 1001 0111 KKdd KKKK */
-  if ((opcode & 0xff00) === 0x9700) {
+  } else if ((opcode & 0xff00) === 0x9700) {
+    /* SBIW, 1001 0111 KKdd KKKK */
     const i = 2 * ((opcode & 0x30) >> 4) + 24;
     const a = cpu.dataView.getUint16(i, true);
     const l = (opcode & 0xf) | ((opcode & 0xc0) >> 2);
@@ -717,97 +575,71 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= 1 & ((~a & l) | (l & R) | (R & ~a)) ? 0x20 : 0;
     cpu.data[95] = sreg;
     cpu.cycles++;
-  }
-
-  /* SBRC, 1111 110r rrrr 0bbb */
-  if ((opcode & 0xfe08) === 0xfc00) {
+  } else if ((opcode & 0xfe08) === 0xfc00) {
+    /* SBRC, 1111 110r rrrr 0bbb */
     if (!(cpu.data[(opcode & 0x1f0) >> 4] & (1 << (opcode & 7)))) {
       const nextOpcode = cpu.progMem[cpu.pc + 1];
       const skipSize = isTwoWordInstruction(nextOpcode) ? 2 : 1;
       cpu.cycles += skipSize;
       cpu.pc += skipSize;
     }
-  }
-
-  /* SBRS, 1111 111r rrrr 0bbb */
-  if ((opcode & 0xfe08) === 0xfe00) {
+  } else if ((opcode & 0xfe08) === 0xfe00) {
+    /* SBRS, 1111 111r rrrr 0bbb */
     if (cpu.data[(opcode & 0x1f0) >> 4] & (1 << (opcode & 7))) {
       const nextOpcode = cpu.progMem[cpu.pc + 1];
       const skipSize = isTwoWordInstruction(nextOpcode) ? 2 : 1;
       cpu.cycles += skipSize;
       cpu.pc += skipSize;
     }
-  }
-
-  /* SLEEP, 1001 0101 1000 1000 */
-  if (opcode === 0x9588) {
+  } else if (opcode === 0x9588) {
+    /* SLEEP, 1001 0101 1000 1000 */
     /* not implemented */
-  }
-
-  /* SPM, 1001 0101 1110 1000 */
-  if (opcode === 0x95e8) {
+  } else if (opcode === 0x95e8) {
+    /* SPM, 1001 0101 1110 1000 */
     /* not implemented */
-  }
-
-  /* SPM(INC), 1001 0101 1111 1000 */
-  if (opcode === 0x95f8) {
+  } else if (opcode === 0x95f8) {
+    /* SPM(INC), 1001 0101 1111 1000 */
     /* not implemented */
-  }
-
-  /* STS, 1001 001d dddd 0000 kkkk kkkk kkkk kkkk */
-  if ((opcode & 0xfe0f) === 0x9200) {
+  } else if ((opcode & 0xfe0f) === 0x9200) {
+    /* STS, 1001 001d dddd 0000 kkkk kkkk kkkk kkkk */
     const value = cpu.data[(opcode & 0x1f0) >> 4];
     const addr = cpu.progMem[cpu.pc + 1];
     cpu.writeData(addr, value);
     cpu.pc++;
     cpu.cycles++;
-  }
-
-  /* STX, 1001 001r rrrr 1100 */
-  if ((opcode & 0xfe0f) === 0x920c) {
+  } else if ((opcode & 0xfe0f) === 0x920c) {
+    /* STX, 1001 001r rrrr 1100 */
     cpu.writeData(cpu.dataView.getUint16(26, true), cpu.data[(opcode & 0x1f0) >> 4]);
-  }
-
-  /* STX(INC), 1001 001r rrrr 1101 */
-  if ((opcode & 0xfe0f) === 0x920d) {
+  } else if ((opcode & 0xfe0f) === 0x920d) {
+    /* STX(INC), 1001 001r rrrr 1101 */
     const x = cpu.dataView.getUint16(26, true);
     cpu.writeData(x, cpu.data[(opcode & 0x1f0) >> 4]);
     cpu.dataView.setUint16(26, x + 1, true);
-  }
-
-  /* STX(DEC), 1001 001r rrrr 1110 */
-  if ((opcode & 0xfe0f) === 0x920e) {
+  } else if ((opcode & 0xfe0f) === 0x920e) {
+    /* STX(DEC), 1001 001r rrrr 1110 */
     const i = cpu.data[(opcode & 0x1f0) >> 4];
     const x = cpu.dataView.getUint16(26, true) - 1;
     cpu.dataView.setUint16(26, x, true);
     cpu.writeData(x, i);
     cpu.cycles++;
-  }
-
-  /* STY, 1000 001r rrrr 1000 */
-  if ((opcode & 0xfe0f) === 0x8208) {
+  } else if ((opcode & 0xfe0f) === 0x8208) {
+    /* STY, 1000 001r rrrr 1000 */
     cpu.writeData(cpu.dataView.getUint16(28, true), cpu.data[(opcode & 0x1f0) >> 4]);
-  }
-
-  /* STY(INC), 1001 001r rrrr 1001 */
-  if ((opcode & 0xfe0f) === 0x9209) {
+  } else if ((opcode & 0xfe0f) === 0x9209) {
+    /* STY(INC), 1001 001r rrrr 1001 */
     const i = cpu.data[(opcode & 0x1f0) >> 4];
     const y = cpu.dataView.getUint16(28, true);
     cpu.writeData(y, i);
     cpu.dataView.setUint16(28, y + 1, true);
-  }
-
-  /* STY(DEC), 1001 001r rrrr 1010 */
-  if ((opcode & 0xfe0f) === 0x920a) {
+  } else if ((opcode & 0xfe0f) === 0x920a) {
+    /* STY(DEC), 1001 001r rrrr 1010 */
     const i = cpu.data[(opcode & 0x1f0) >> 4];
     const y = cpu.dataView.getUint16(28, true) - 1;
     cpu.dataView.setUint16(28, y, true);
     cpu.writeData(y, i);
     cpu.cycles++;
-  }
-
-  /* STDY, 10q0 qq1r rrrr 1qqq */
-  if (
+  } else if (
+    /* STDY, 10q0 qq1r rrrr 1qqq */
     (opcode & 0xd208) === 0x8208 &&
     (opcode & 7) | ((opcode & 0xc00) >> 7) | ((opcode & 0x2000) >> 8)
   ) {
@@ -817,31 +649,23 @@ export function avrInstruction(cpu: ICPU) {
       cpu.data[(opcode & 0x1f0) >> 4]
     );
     cpu.cycles++;
-  }
-
-  /* STZ, 1000 001r rrrr 0000 */
-  if ((opcode & 0xfe0f) === 0x8200) {
+  } else if ((opcode & 0xfe0f) === 0x8200) {
+    /* STZ, 1000 001r rrrr 0000 */
     cpu.writeData(cpu.dataView.getUint16(30, true), cpu.data[(opcode & 0x1f0) >> 4]);
-  }
-
-  /* STZ(INC), 1001 001r rrrr 0001 */
-  if ((opcode & 0xfe0f) === 0x9201) {
+  } else if ((opcode & 0xfe0f) === 0x9201) {
+    /* STZ(INC), 1001 001r rrrr 0001 */
     const z = cpu.dataView.getUint16(30, true);
     cpu.writeData(z, cpu.data[(opcode & 0x1f0) >> 4]);
     cpu.dataView.setUint16(30, z + 1, true);
-  }
-
-  /* STZ(DEC), 1001 001r rrrr 0010 */
-  if ((opcode & 0xfe0f) === 0x9202) {
+  } else if ((opcode & 0xfe0f) === 0x9202) {
+    /* STZ(DEC), 1001 001r rrrr 0010 */
     const i = cpu.data[(opcode & 0x1f0) >> 4];
     const z = cpu.dataView.getUint16(30, true) - 1;
     cpu.dataView.setUint16(30, z, true);
     cpu.writeData(z, i);
     cpu.cycles++;
-  }
-
-  /* STDZ, 10q0 qq1r rrrr 0qqq */
-  if (
+  } else if (
+    /* STDZ, 10q0 qq1r rrrr 0qqq */
     (opcode & 0xd208) === 0x8200 &&
     (opcode & 7) | ((opcode & 0xc00) >> 7) | ((opcode & 0x2000) >> 8)
   ) {
@@ -851,10 +675,8 @@ export function avrInstruction(cpu: ICPU) {
       cpu.data[(opcode & 0x1f0) >> 4]
     );
     cpu.cycles++;
-  }
-
-  /* SUB, 0001 10rd dddd rrrr */
-  if ((opcode & 0xfc00) === 0x1800) {
+  } else if ((opcode & 0xfc00) === 0x1800) {
+    /* SUB, 0001 10rd dddd rrrr */
     const val1 = cpu.data[(opcode & 0x1f0) >> 4];
     const val2 = cpu.data[(opcode & 0xf) | ((opcode & 0x200) >> 5)];
     const R = val1 - val2;
@@ -868,10 +690,8 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= val2 > val1 ? 1 : 0;
     sreg |= 1 & ((~val1 & val2) | (val2 & R) | (R & ~val1)) ? 0x20 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* SUBI, 0101 KKKK dddd KKKK */
-  if ((opcode & 0xf000) === 0x5000) {
+  } else if ((opcode & 0xf000) === 0x5000) {
+    /* SUBI, 0101 KKKK dddd KKKK */
     const val1 = cpu.data[((opcode & 0xf0) >> 4) + 16];
     const val2 = (opcode & 0xf) | ((opcode & 0xf00) >> 4);
     const R = val1 - val2;
@@ -884,22 +704,16 @@ export function avrInstruction(cpu: ICPU) {
     sreg |= val2 > val1 ? 1 : 0;
     sreg |= 1 & ((~val1 & val2) | (val2 & R) | (R & ~val1)) ? 0x20 : 0;
     cpu.data[95] = sreg;
-  }
-
-  /* SWAP, 1001 010d dddd 0010 */
-  if ((opcode & 0xfe0f) === 0x9402) {
+  } else if ((opcode & 0xfe0f) === 0x9402) {
+    /* SWAP, 1001 010d dddd 0010 */
     const d = (opcode & 0x1f0) >> 4;
     const i = cpu.data[d];
     cpu.data[d] = ((15 & i) << 4) | ((240 & i) >>> 4);
-  }
-
-  /* WDR, 1001 0101 1010 1000 */
-  if (opcode === 0x95a8) {
+  } else if (opcode === 0x95a8) {
+    /* WDR, 1001 0101 1010 1000 */
     /* not implemented */
-  }
-
-  /* XCH, 1001 001r rrrr 0100 */
-  if ((opcode & 0xfe0f) === 0x9204) {
+  } else if ((opcode & 0xfe0f) === 0x9204) {
+    /* XCH, 1001 001r rrrr 0100 */
     const r = (opcode & 0x1f0) >> 4;
     const val1 = cpu.data[r];
     const val2 = cpu.data[cpu.dataView.getUint16(30, true)];

--- a/src/instruction.ts
+++ b/src/instruction.ts
@@ -25,8 +25,8 @@ function isTwoWordInstruction(opcode: u16) {
 export function avrInstruction(cpu: ICPU) {
   const opcode = cpu.progMem[cpu.pc];
 
-  /* ADC, 0001 11rd dddd rrrr */
   if ((opcode & 0xfc00) === 0x1c00) {
+    /* ADC, 0001 11rd dddd rrrr */
     const d = cpu.data[(opcode & 0x1f0) >> 4];
     const r = cpu.data[(opcode & 0xf) | ((opcode & 0x200) >> 5)];
     const sum = d + r + (cpu.data[95] & 1);


### PR DESCRIPTION
Hello,

First I'd like to thank you for this great project. I am teaching the basics of embedded systems and this could be a great resource for me in the future !

While I was taking a look at the source code I came along this quick optimization in the instruction code. I hope I didn't miss something obvious.

Simply replacing `if` with `else if` provides a welcomed performance boost.
All these `if` on every opcode adds up, so adding `else if` reduces the amount of checks per opcode.

However I liked the clear opcode separation by a line but the prettier doesn't allow this with `else if` so it is a bit ugly and condensed now.

I am not too familiar with hardware simulators but my guess would be that use of a map of opcodes    or switch statements would provide even greater benefits.

With this PR the last instruction still requires evaluation of all the preceding `if` and `else if`.

## Benchmarks

Before this PR:
```
Benchmark: cpu-benchmark
  avrInstruction: 66.145 ns(-117%)
  avrInstructionObjMap: 30.535 ns(0%)
  avrInstructionUintArray: 50.937 ns(-67%)
```

With this PR:
```
Benchmark: cpu-benchmark
  avrInstruction: 47.811 ns(-58%)
  avrInstructionObjMap: 30.208 ns(0%)
  avrInstructionUintArray: 51.428 ns(-70%)
```