### PR TITLE
Improve main cpu loop performance

### DIFF
--- a/demo/src/task-scheduler.spec.ts
+++ b/demo/src/task-scheduler.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+/// <reference lib="dom" />
+
+import { MicroTaskScheduler } from './task-scheduler';
+
+describe('task-scheduler', () => {
+  let taskScheduler: MicroTaskScheduler;
+  let task: jest.Mock;
+
+  beforeEach(() => {
+    taskScheduler = new MicroTaskScheduler();
+    task = jest.fn();
+  });
+
+  it('should execute task', async () => {
+    taskScheduler.start();
+    taskScheduler.postTask(task);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it('should execute task twice when posted twice', async () => {
+    taskScheduler.start();
+    taskScheduler.postTask(task);
+    taskScheduler.postTask(task);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(task).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not execute task when not started', async () => {
+    taskScheduler.postTask(task);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(task).not.toHaveBeenCalled();
+  });
+
+  it('should not execute task when stopped', async () => {
+    taskScheduler.start();
+    taskScheduler.stop();
+    taskScheduler.postTask(task);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(task).not.toHaveBeenCalled();
+  });
+
+  it('should not register listener twice', async () => {
+    const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+    taskScheduler.start();
+    taskScheduler.start();
+    expect(addEventListenerSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/demo/src/task-scheduler.ts
+++ b/demo/src/task-scheduler.ts
@@ -1,0 +1,39 @@
+// Faster setTimeout(fn, 0) implementation using postMessage API
+// Based on https://dbaron.org/log/20100309-faster-timeouts
+export type IMicroTaskCallback = () => void;
+
+export class MicroTaskScheduler {
+  readonly messageName = 'zero-timeout-message';
+
+  private executionQueue: Array<IMicroTaskCallback> = [];
+  private stopped = true;
+
+  start() {
+    if (this.stopped) {
+      this.stopped = false;
+      window.addEventListener('message', this.handleMessage, true);
+    }
+  }
+
+  stop() {
+    this.stopped = true;
+    window.removeEventListener('message', this.handleMessage, true);
+  }
+
+  postTask(fn: IMicroTaskCallback) {
+    if (!this.stopped) {
+      this.executionQueue.push(fn);
+      window.postMessage(this.messageName, '*');
+    }
+  }
+
+  private handleMessage = (event: MessageEvent) => {
+    if (event.data === this.messageName) {
+      event.stopPropagation();
+      const executeJob = this.executionQueue.shift();
+      if (executeJob !== undefined) {
+        executeJob();
+      }
+    }
+  };
+}


### PR DESCRIPTION
Working branch for #18 

## Benchmark on Demo

baseline:  setTimeout(resolve, 0)) 

Function | Performance change
------------ | -------------| 
window.requestAnimationFrame(resolve)   | **+ ~10%** performance on chrome
setZeroTimeout(resolve) |  **+ ~20%** performance on chrome

Perf on Firefox is unchanged, which is quite disappointing

## Profiling
I tried to do some profiling to spot differences between Firefox and Chrome

My main discovery is that on Chrome, "Micro tasks" each take about ~20ms to run. On Firefox "Dom Events" (which i think refers to the same thing as Chrome Micro tasks" take about ~100ms so about 5 times more.

This may be a coincidence but i have ~150% simulation time on chrome and ~30% on Firefox, 5 time less.

I have an intuition that the infinite for loop may be causing this. 
So I'll have a try at refactoring the async execute function to run without using await, but by enqueuing execution task at the end of the function. Like this: 

```javascript
execute() {
  tick();
  // ...
  setZeroTimeout(execute, 0); 
}
```

I'll see how this goes !